### PR TITLE
static arp entries have no age in eAPI

### DIFF
--- a/napalm_eos/eos.py
+++ b/napalm_eos/eos.py
@@ -807,7 +807,7 @@ class EOSDriver(NetworkDriver):
             interface = py23_compat.text_type(neighbor.get('interface'))
             mac_raw = neighbor.get('hwAddress')
             ip = py23_compat.text_type(neighbor.get('address'))
-            age = float(neighbor.get('age'))
+            age = float(neighbor.get('age', 0.0))
             arp_table.append(
                 {
                     'interface': interface,


### PR DESCRIPTION
<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
eAPI return no "age" key for static arp entries causing float() to raise a TypeError exception.<br>
<br>
Defaulting to 0.0 resolves it although one could question the correctness of it. <br>
<br>
In general, the data model should include a mention of if the arp entry is dynamic or static.